### PR TITLE
Java 11 fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>gov.nih.ncats</groupId>
   <artifactId>molvec</artifactId>
   <packaging>jar</packaging>
-  <version>0.9.4</version>
+  <version>0.9.5</version>
   <name>MolVec</name>
 
 
@@ -211,10 +211,10 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
+	    <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -222,9 +222,12 @@
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <use>false</use>
+                            <use>false</use>
+                            <source>1.8</source>
+                                <links><link>http://docs.oracle.com/javase/7/docs/api/</link>		                             <link>http://docs.oracle.com/javase/7/docs/api/</link></links>
+                            <doclint>none</doclint>
                         </configuration>
-
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/java/gov/nih/ncats/molvec/image/Grayscale.java
+++ b/src/main/java/gov/nih/ncats/molvec/image/Grayscale.java
@@ -71,6 +71,8 @@ public class Grayscale {
         
         int maxAlpha=0;
         int minAlpha=255;
+        int moreAlphaCount=0;
+        int lessAlphaCount=0;
         
         //Assumes RGBA
         if(nband>=4) {
@@ -81,6 +83,9 @@ public class Grayscale {
         		    int pixel = row[i];
                     if (pixel > maxAlpha) maxAlpha = pixel;
                     if (pixel < minAlpha) minAlpha = pixel;
+                    if(pixel > 128) moreAlphaCount++;
+                    if(pixel <= 128) lessAlphaCount++;
+                    
         	    }
         	}
         }
@@ -109,6 +114,13 @@ public class Grayscale {
         			}else {
         				pp[3]=(pp[3]-minAlpha)/(maxAlpha-minAlpha);
         				pp[3]*=255;
+        				//assume that there's supposed to be more
+        				//transparent things than opaque things.
+        				//If that's not the case, invert the alpha
+        				//channel
+        				if(moreAlphaCount>lessAlphaCount) {
+        					pp[3]=255-pp[3];
+        				}
         			}
         		}
         		


### PR DESCRIPTION
The pull request should fix an issue where some default java8 library, as far as I can tell, used to read in some PNGs in such a way that the alpha channel being "255" meant "transparent", but in java11 it now instead means "opaque". No doubt this confusion has to do with deep definitions of color models that can be inspected/analyzed, but that's beyond my attention span. 

When MolVec reads in an image, it first flattens it to a single-channel grayscale image. To do this, it applies a certain transform if the colorspace is RGB, and a slightly different transform if it's RGBA. For the extra alpha channel, it tries to count alpha as just a multiplier to the underlying RGB transform, so an _especially_ transparent pixel gets multiplied by 0, and an _especially_ opaque pixel gets multiplied by 1. The alpha scale is now inverted for many images when run on a java11+ JRE, so this effectively ends up producing completely blank images since everything is viewed as transparent.

There are 4 fixes to help with this:

1. 255 now always means "opaque" internally to MolVec when generating a flat grayscale image
2. If there is an alpha channel but it has the same value for all pixels, it is explicitly set to be 255 for all pixels.
3. If the alpha channel does vary, the alpha channel is rescaled to be between 0 and 255
4. Also, if the alpha channel varies, and there are more >128 alpha pixels than <128 alpha pixels, invert the alpha channel to be 255-alpha. The assumption here is that if there's meaningful alpha, it's probably the negative space. There should be more negative space than positive space for chemical images with alpha.

None of these are "perfect" fixes. A safer thing to do is probably render any image with an alpha channel on both a white and black background first using standard abstraction layers, and then use the image which maintains the highest dynamic range. But the above fixes do make the tests work for both java8 and java11, so it seems sufficient for now.