### PR TITLE
Npe fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MolVec
-NCATS (chemical) ocr engine that can a way to vectorize
+NCATS (chemical) ocr engine that can vectorize
 chemical images into Chemical objects preserving the 2D layout as much as 
 possible. The code is still very raw in terms of utility. Check
 out [https://molvec.ncats.io](https://molvec.ncats.io) for a
@@ -37,16 +37,16 @@ For Maven:
 ## Commandline interface
   The Molvec jar has a runnable Main class with the following options
   
-    usage: molvec ([-gui],[[(-f <path> [-o <path>]) | (-dir <path> [-outDir <path>],[-parallel <count>])]],[-scale <value>],[-h])
-    
+    usage: molvec ([-gui],[[(-f <path> [-o <path>]) | (-dir <path> [[-outDir <path> | -outSdf <path>]],[-parallel <count>])]],[-scale
+                  <value>],[-h])
     Image to Chemical Structure Extractor Analyzes the given image and tries to find the chemical structure drawn and
     convert it into a Mol format.
     
     options:
-         -dir <path>         path to a directory of image files to process. Supported formats include png, jpeg, tiff. Each
-                             image file found will be attempted to be processed. If -out or -outDir is not specified then
-                             each processed mol will be put in the same directory and named $filename.molThis option or -f
-                             is required if not using -gui
+         -dir <path>         path to a directory of image files to process. Supported formats include png, jpeg, tiff and
+                             svg. Each image file found will be attempted to be processed. If -out or -outDir is not
+                             specified then each processed mol will be put in the same directory and named
+                             $filename.molThis option or -f is required if not using -gui
     
          -f,--file <path>    path of image file to process. Supported formats include png, jpeg, tiff.  This option or -dir
                              is required if not using -gui
@@ -60,6 +60,8 @@ For Maven:
     
          -outDir <path>      path to output directory to put processed mol files. If this path does not exist it will e
                              created
+    
+         -outSdf <path>      Write output to a single sdf formatted file instead of individual mol files
     
          -parallel <count>   Number of images to process simultaneously, if not specified defaults to 1
     
@@ -81,6 +83,16 @@ For Maven:
        serially parse all the image files inside the given directory and write out a new mol file for each image named
        $image.file.mol the new files will be put in the directory specified by outDir
     
+          $molvec -dir /path/to/directory -outSdf /path/to/output.sdf
+    
+       serially parse all the image files inside the given directory and write out a new sdf file to the given path that
+       contains all the structures from the input image directory
+    
+          $molvec -dir /path/to/directory -outSdf /path/to/output.sdf -parallel 4
+    
+       parse in 4 concurrent parallel thread all the image files inside the given directory and write out a new sdf file to
+       the given path that contains all the structures from the input image directory
+    
           $molvec -dir /path/to/directory -parallel 4
     
        parse in 4 concurrent parallel threads all the image files inside the given directory and write out a new mol file for
@@ -97,7 +109,9 @@ For Maven:
           $molvec -gui -f /path/to/image.file -scale 2.0
     
        open the Molvec Graphical User interface  with the given image file preloaded zoomed in/out to the given scale
-                       
+    
+    Developed by NIH/NCATS
+                    
 ### GUI
   Molvec Comes with a Swing Viewer you can use to step
   through each step of the structure recognition process

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>gov.nih.ncats</groupId>
   <artifactId>molvec</artifactId>
   <packaging>jar</packaging>
-  <version>0.9.8</version>
+  <version>0.9.8-SNAPSHOT</version>
   <name>MolVec</name>
 
 
@@ -115,7 +115,7 @@
         <version>0.9.2</version>
     </dependency>
 
-<dependency>
+    <dependency>
         <groupId>gov.nih.ncats</groupId>
         <artifactId>molwitch-cdk</artifactId>
         <version>1.0.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -102,17 +102,17 @@
     <dependency>
         <groupId>com.twelvemonkeys.imageio</groupId>
         <artifactId>imageio-tiff</artifactId>
-        <version>3.4.1</version>
+        <version>3.6</version>
     </dependency>
     <dependency>
         <groupId>gov.nih.ncats</groupId>
         <artifactId>ncats-common</artifactId>
-        <version>0.3.3</version>
+        <version>0.3.4</version>
     </dependency>
     <dependency>
         <groupId>gov.nih.ncats</groupId>
         <artifactId>ncats-common-cli</artifactId>
-        <version>0.9.1</version>
+        <version>0.9.2</version>
     </dependency>
 
 <dependency>

--- a/src/main/java/gov/nih/ncats/molvec/ErrorResult.java
+++ b/src/main/java/gov/nih/ncats/molvec/ErrorResult.java
@@ -1,0 +1,34 @@
+package gov.nih.ncats.molvec;
+
+import java.awt.geom.Rectangle2D;
+import java.util.Objects;
+import java.util.Optional;
+
+class ErrorResult implements MolvecResult{
+
+    private final Throwable t;
+
+    public ErrorResult(Throwable t) {
+        this.t = Objects.requireNonNull(t);
+    }
+
+    @Override
+    public Optional<String> getMol() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Rectangle2D> getOriginalBoundingBox() {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean hasError() {
+        return true;
+    }
+
+    @Override
+    public Optional<Throwable> getError() {
+        return Optional.of(t);
+    }
+}

--- a/src/main/java/gov/nih/ncats/molvec/ErrorResult.java
+++ b/src/main/java/gov/nih/ncats/molvec/ErrorResult.java
@@ -1,6 +1,7 @@
 package gov.nih.ncats.molvec;
 
 import java.awt.geom.Rectangle2D;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -14,6 +15,16 @@ class ErrorResult implements MolvecResult{
 
     @Override
     public Optional<String> getMolfile() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> getSDfile() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> getSDfile(Map<String, String> properties) {
         return Optional.empty();
     }
 

--- a/src/main/java/gov/nih/ncats/molvec/ErrorResult.java
+++ b/src/main/java/gov/nih/ncats/molvec/ErrorResult.java
@@ -13,7 +13,7 @@ class ErrorResult implements MolvecResult{
     }
 
     @Override
-    public Optional<String> getMol() {
+    public Optional<String> getMolfile() {
         return Optional.empty();
     }
 

--- a/src/main/java/gov/nih/ncats/molvec/Main.java
+++ b/src/main/java/gov/nih/ncats/molvec/Main.java
@@ -256,13 +256,25 @@ public class Main {
 
                         executorService.submit(()-> {
                             try (PrintWriter sdfWriter = new PrintWriter(directoryProcessor.getSdfOut())) {
-
+                                StringBuilder buffer = new StringBuilder(100_000);
+                                int currentCount=0;
                                 while (true) {
                                     String nextRecord = blockingQueue.take();
                                     if (nextRecord == POISON_PILL) {
                                         break;
                                     }
-                                    sdfWriter.print(nextRecord);
+                                    buffer.append(nextRecord);
+                                    currentCount++;
+                                    if(currentCount==100){
+                                        sdfWriter.print(buffer.toString());
+                                        currentCount=0;
+                                        buffer.setLength(0);
+                                    }
+                                }
+                                if(buffer.length() >0){
+                                    //write any remaining records
+                                    sdfWriter.print(buffer.toString());
+
                                 }
                             } catch (Exception e) {
                                 e.printStackTrace();

--- a/src/main/java/gov/nih/ncats/molvec/Main.java
+++ b/src/main/java/gov/nih/ncats/molvec/Main.java
@@ -3,14 +3,12 @@ package gov.nih.ncats.molvec;
 import gov.nih.ncats.common.cli.Cli;
 import gov.nih.ncats.common.cli.CliSpecification;
 import gov.nih.ncats.common.cli.CliValidationException;
+import gov.nih.ncats.common.functions.ThrowableConsumer;
 import gov.nih.ncats.molvec.ui.Viewer;
 
 import java.io.*;
 import java.nio.file.Files;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.*;
 
 import static gov.nih.ncats.common.cli.CliSpecification.*;
 /**
@@ -21,7 +19,7 @@ public class Main {
     private static class DirectoryProcessor{
         private int numThreads =1;
 
-        private File dir, outputDir;
+        private File dir, outputDir, sdfOut;
 
         public int getNumThreads() {
             return numThreads;
@@ -32,6 +30,18 @@ public class Main {
                 throw new CliValidationException("num of threads must be >=1");
             }
             this.numThreads = numThreads;
+        }
+
+        public File getSdfOut() {
+            return sdfOut;
+        }
+
+        public void setSdfOut(File sdfOut) throws IOException{
+            this.sdfOut = sdfOut;
+            File parent = sdfOut.getParentFile();
+            if(parent !=null){
+                Files.createDirectories(parent.toPath());
+            }
         }
 
         public File getDir() {
@@ -84,14 +94,20 @@ public class Main {
                                         "This option or -f is required if not using -gui")
                                 .setToFile(directoryProcessor::setDir)
                                 .setRequired(true),
-                                option("outDir")
-                                    .argName("path")
-                                        .setToFile(directoryProcessor::setOutputDir)
-                                    .description("path to output directory to put processed mol files. If this path does not exist it will e created"),
+                            radio(option("outDir")
+                                            .argName("path")
+                                            .setToFile(directoryProcessor::setOutputDir)
+                                            .description("path to output directory to put processed mol files. If this path does not exist it will e created"),
+                                    option("outSdf")
+                                            .argName("path")
+                                            .setToFile(directoryProcessor::setSdfOut)
+                                            .description("Write output to a single sdf formatted file instead of individual mol files")
+                            ),
                                 option("parallel")
                                         .argName("count")
                                         .setToInt(directoryProcessor::setNumThreads)
                                         .description("Number of images to process simultaneously, if not specified defaults to 1")
+
 
 
 
@@ -113,8 +129,13 @@ public class Main {
                         "a new mol file for each image named $image.file.mol the new files will be put in the input directory")
         .example("-dir /path/to/directory -outDir /path/to/outputDir", "serially parse all the image files inside the given directory and write out " +
                         "a new mol file for each image named $image.file.mol the new files will be put in the directory specified by outDir")
+        .example("-dir /path/to/directory -outSdf /path/to/output.sdf", "serially parse all the image files inside the given directory and write out " +
+                "a new sdf file to the given path that contains all the structures from the input image directory ")
+        .example("-dir /path/to/directory -outSdf /path/to/output.sdf -parallel 4", "parse in 4 concurrent parallel thread all the image files inside the given directory and write out " +
+                "a new sdf file to the given path that contains all the structures from the input image directory ")
+
         .example("-dir /path/to/directory -parallel 4", "parse in 4 concurrent parallel threads all the image files inside the given directory and write out " +
-                        "a new mol file for each image named $image.file.mol the new files will be put in the directory specified by outDir")
+                "a new mol file for each image named $image.file.mol the new files will be put in the directory specified by outDir")
 
         .example("-gui", "open the Molvec Graphical User interface without any image preloaded")
         .example("-gui -f /path/to/image.file", "open the Molvec Graphical User interface  with the given image file preloaded")
@@ -169,7 +190,6 @@ public class Main {
                 if(outputDir ==null){
                     outputDir = dir;
                 }
-                ExecutorService executorService = Executors.newFixedThreadPool(directoryProcessor.getNumThreads());
                 File files[] =dir.listFiles( f->{
                     String name = f.getName();
                     int extOffset = name.lastIndexOf('.');
@@ -188,12 +208,103 @@ public class Main {
                     System.out.println("No image files found");
                     return;
                 }
-                CountDownLatch latch = new CountDownLatch(files.length);
-                for(File f : files){
-                    executorService.submit(new MolVecRunnable(f, outputDir, latch));
+
+                int numThreads = directoryProcessor.getNumThreads();
+                if(numThreads ==1){
+                    //run in serial
+                    if(cli.hasOption("outSdf")){
+                        //write out as single sdf file
+                        String lineSep = System.lineSeparator();
+                        try (PrintWriter writer = new PrintWriter(directoryProcessor.getSdfOut())) {
+                            for (File f : files) {
+                                try {
+                                    String mol = Molvec.ocr(f);
+                                    writer.println(mol + lineSep +"$$$$");
+                                } catch (Throwable t) {
+                                    System.err.println("error processing file " + f.getName());
+                                    t.printStackTrace();
+                                }
+                            }
+                        }
+                    }else {
+                        for (File f : files) {
+                            try {
+                                String mol = Molvec.ocr(f);
+                                File out = new File(outputDir, f.getName() + ".mol");
+                                try (PrintWriter writer = new PrintWriter(out)) {
+                                    writer.println(mol);
+                                }
+                            } catch (Throwable t) {
+                                System.err.println("error processing file " + f.getName());
+                                t.printStackTrace();
+                            }
+                        }
+                    }
+                }else {
+                    ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+
+                    CountDownLatch latch = new CountDownLatch(files.length);
+
+                    if(cli.hasOption("outSdf")){
+                        //write everything to one sdf file.
+                        BlockingQueue<String> blockingQueue = new ArrayBlockingQueue<String>(16);
+                        String POISON_PILL = "END_OF_WRITING";
+
+                        executorService.submit(()-> {
+                            try (PrintWriter sdfWriter = new PrintWriter(directoryProcessor.getSdfOut())) {
+
+                                while (true) {
+                                    String nextRecord = blockingQueue.take();
+                                    if (nextRecord == POISON_PILL) {
+                                        break;
+                                    }
+                                    sdfWriter.print(nextRecord);
+                                }
+                            } catch (Exception e) {
+                                e.printStackTrace();
+                            }
+                        });
+
+
+                            for (File f : files) {
+                                String lineSep = System.lineSeparator();
+                                executorService.submit(new MolVecRunnable(f, latch,
+                                        mol -> {
+                                            try {
+                                                blockingQueue.put(mol + lineSep  +"$$$$"+lineSep);
+                                            } catch (InterruptedException e) {
+                                                e.printStackTrace();
+                                            }
+                                        }
+
+
+                                ));
+                            }
+
+                            latch.await();
+                            //when we get here we've written out all of our records
+                        blockingQueue.put(POISON_PILL);
+                        executorService.shutdown();
+
+                    }else {
+                        //we have to do this to make the compiler happy to use this inside a lambda
+                        //since outputDir can be set a few different ways.
+                        final File effectivelyFinalOutputDir = outputDir;
+                        for (File f : files) {
+                            executorService.submit(new MolVecRunnable(f, latch,
+                                    mol -> {
+                                        File out = new File(effectivelyFinalOutputDir, f.getName() + ".mol");
+                                        try (PrintWriter writer = new PrintWriter(out)) {
+                                            writer.println(mol);
+                                        }
+                                    }
+                            ));
+                        }
+                        executorService.shutdown();
+                        latch.await();
+                    }
+
                 }
-                executorService.shutdown();
-                latch.await();
             }else{
                 //invalid
                 throw new CliValidationException("gui mode or file not specified");
@@ -208,28 +319,35 @@ public class Main {
 
     private static class MolVecRunnable implements Callable<Void>{
         File f;
-        File outDir;
         CountDownLatch latch;
-        MolVecRunnable(File f, File outDir, CountDownLatch latch){
+        ThrowableConsumer<String, IOException> molConsumer;
+        MolVecRunnable(File f, CountDownLatch latch, ThrowableConsumer<String, IOException> molConsumer){
             this.f =f;
-            this.outDir = outDir;
             this.latch = latch;
+            this.molConsumer = molConsumer;
         }
 
         @Override
         public Void call() throws Exception{
             try {
                 System.out.println(" .."+f.getName());
-                String mol = Molvec.ocr(f);
-                File out = new File(outDir, f.getName() + ".mol");
-                try (PrintWriter writer = new PrintWriter(out)) {
-                    writer.println(mol);
-                }
+                String name = getBaseNameFor(f.getName());
+                MolvecResult mol = Molvec.ocr(f, new MolvecOptions().setName(name));
+                molConsumer.accept(mol.getMol().get());
+
                 return null;
             }finally{
                 //wait until the end to decrement latch
                 latch.countDown();
             }
+        }
+
+        private static String getBaseNameFor(String fileName){
+            int index = fileName.lastIndexOf('.');
+            if(index >0){
+                return fileName.substring(0, index);
+            }
+            return fileName;
         }
     }
 }

--- a/src/main/java/gov/nih/ncats/molvec/Main.java
+++ b/src/main/java/gov/nih/ncats/molvec/Main.java
@@ -8,6 +8,8 @@ import gov.nih.ncats.molvec.ui.Viewer;
 
 import java.io.*;
 import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.*;
 
 import static gov.nih.ncats.common.cli.CliSpecification.*;
@@ -272,8 +274,12 @@ public class Main {
                                 String lineSep = System.lineSeparator();
                                 executorService.submit(new MolVecRunnable(f, latch,
                                         mol -> {
+                                    System.out.println(".." + f.getName());
                                             try {
-                                                blockingQueue.put(mol.getSDfile().get() + lineSep);
+                                                Map<String, String> props = new HashMap<>();
+                                                props.put("Molecule Name", getBaseNameFor(f.getName()));
+                                                props.put("File Name", f.getName());
+                                                blockingQueue.put(mol.getSDfile(props).get() + lineSep);
                                             } catch (InterruptedException e) {
                                                 e.printStackTrace();
                                             }

--- a/src/main/java/gov/nih/ncats/molvec/Molvec.java
+++ b/src/main/java/gov/nih/ncats/molvec/Molvec.java
@@ -23,7 +23,7 @@ public final class Molvec {
 	 * @throws NullPointerException if image is null.
 	 */
 	public static String ocr(File image) throws IOException{
-		return ocr(image, DEFAULT_OPTIONS).getMol().get();
+		return ocr(image, DEFAULT_OPTIONS).getMolfile().get();
 		
 	}
 
@@ -61,7 +61,7 @@ public final class Molvec {
 	 * @throws NullPointerException if image is null.
 	 */
 	public static String ocr(byte[] image) throws IOException{
-		return ocr(image, DEFAULT_OPTIONS).getMol().get();
+		return ocr(image, DEFAULT_OPTIONS).getMolfile().get();
 
 	}
 
@@ -97,7 +97,7 @@ public final class Molvec {
 	 * @throws NullPointerException if image is null.
 	 */
 	public static String ocr(BufferedImage image) throws IOException{
-		return ocr(image, DEFAULT_OPTIONS).getMol().get();
+		return ocr(image, DEFAULT_OPTIONS).getMolfile().get();
 		
 	}
 	/**

--- a/src/main/java/gov/nih/ncats/molvec/Molvec.java
+++ b/src/main/java/gov/nih/ncats/molvec/Molvec.java
@@ -14,6 +14,7 @@ import gov.nih.ncats.molvec.internal.algo.StructureImageExtractor;
  */
 public final class Molvec {
 
+	private static MolvecOptions DEFAULT_OPTIONS = new MolvecOptions();
 	/**
 	 * Analyze the given image and try to recognize a molecular structure.
 	 * @param image the image to analyze, can not be null.
@@ -22,11 +23,31 @@ public final class Molvec {
 	 * @throws NullPointerException if image is null.
 	 */
 	public static String ocr(File image) throws IOException{
+		return ocr(image, DEFAULT_OPTIONS).getMol().get();
+		
+	}
+
+	/**
+	 * Analyze the given image and try to recognize a molecular structure
+	 * and compute a {@link MolvecResult} using the given {@link MolvecOptions}.
+	 * @param image the image to analyze, can not be null.
+	 *
+	 * @param options the {@link MolvecOptions} to use; if options is null, then the default options are used.
+	 *
+	 * @return a {@link MolvecResult} which includes a String encoded in mol format of the recognized molecular structure.
+	 * @throws IOException if there are any problems parsing the images.
+	 * @throws NullPointerException if image is null.
+	 *
+	 * @since 0.9.8
+	 */
+	public static MolvecResult ocr(File image, MolvecOptions options) throws IOException{
 		checkNotNull(image);
 		StructureImageExtractor sie = new StructureImageExtractor(image);
-		String mol = sie.getCtab().toMol();
-		return mol;
-		
+		if(options ==null) {
+			return DEFAULT_OPTIONS.computeResult(sie.getCtab());
+		}
+		return options.computeResult(sie.getCtab());
+
 	}
 
 	private static void checkNotNull(Object obj){
@@ -40,9 +61,32 @@ public final class Molvec {
 	 * @throws NullPointerException if image is null.
 	 */
 	public static String ocr(byte[] image) throws IOException{
+		return ocr(image, DEFAULT_OPTIONS).getMol().get();
+
+	}
+
+	/**
+	 * Analyze the given image encoded data as a bytre array and try to recognize a molecular structure
+	 * and compute a {@link MolvecResult} using the given {@link MolvecOptions}.
+	 *
+	 * @param image the image to analyze, can not be null.
+	 *
+	 * @param options the {@link MolvecOptions} to use; if options is null, then the default options are used.
+	 *
+	 * @return a {@link MolvecResult} which includes a String encoded in mol format of the recognized molecular structure.
+	 *
+	 * @throws IOException if there are any problems parsing the images.
+	 * @throws NullPointerException if image is null.
+	 *
+	 * @since 0.9.8
+	 */
+	public static MolvecResult ocr(byte[] image, MolvecOptions options) throws IOException{
 		checkNotNull(image);
 		StructureImageExtractor sie = new StructureImageExtractor(image);
-			return sie.getCtab().toMol();
+		if(options ==null) {
+			return DEFAULT_OPTIONS.computeResult(sie.getCtab());
+		}
+		return options.computeResult(sie.getCtab());
 
 	}
 	/**
@@ -53,10 +97,31 @@ public final class Molvec {
 	 * @throws NullPointerException if image is null.
 	 */
 	public static String ocr(BufferedImage image) throws IOException{
+		return ocr(image, DEFAULT_OPTIONS).getMol().get();
+		
+	}
+	/**
+	 * Analyze the given image and try to recognize a molecular structure
+	 * and compute a {@link MolvecResult} using the given {@link MolvecOptions}.
+	 *
+	 * @param image the image to analyze, can not be null.
+	 * @param options the {@link MolvecOptions} to use; if options is null, then the default options are used.
+	 *
+	 * @return a {@link MolvecResult} which includes a String encoded in mol format of the recognized molecular structure.
+	 *
+	 * @throws IOException if there are any problems parsing the images.
+	 * @throws NullPointerException if image is null.
+	 *
+	 * @since 0.9.8
+	 */
+	public static MolvecResult ocr(BufferedImage image, MolvecOptions options) throws IOException{
 		checkNotNull(image);
 		StructureImageExtractor sie = StructureImageExtractor.createFromImage(image);
-		return sie.getCtab().toMol();
-		
+		if(options ==null) {
+			return DEFAULT_OPTIONS.computeResult(sie.getCtab());
+		}
+		return options.computeResult(sie.getCtab());
+
 	}
 	public static CompletableFuture<String> ocrAsync(byte[] image){
 		return CompletableFuture.supplyAsync(() -> {
@@ -65,6 +130,16 @@ public final class Molvec {
 			}catch(Exception e){
 				e.printStackTrace();
 				return null;
+			}
+		});
+	}
+
+	public static CompletableFuture<MolvecResult> ocrAsync(byte[] image, MolvecOptions options){
+		return CompletableFuture.supplyAsync(() -> {
+			try{
+				return ocr(image, options);
+			}catch(Exception e){
+				return MolvecResult.createFromError(e);
 			}
 		});
 	}
@@ -79,6 +154,15 @@ public final class Molvec {
 			}
 		});
 	}
+	public static CompletableFuture<MolvecResult> ocrAsync(File image, MolvecOptions options){
+		return CompletableFuture.supplyAsync(() -> {
+			try{
+				return ocr(image, options);
+			}catch(Exception e){
+				return MolvecResult.createFromError(e);
+			}
+		});
+	}
 	public static CompletableFuture<String> ocrAsync(File image, Executor executor){
 		return CompletableFuture.supplyAsync(() -> {
 			try{
@@ -86,6 +170,16 @@ public final class Molvec {
 			}catch(Exception e){
 				e.printStackTrace();
 				return null;
+			}
+		},executor);
+	}
+
+	public static CompletableFuture<MolvecResult> ocrAsync(File image, MolvecOptions options, Executor executor){
+		return CompletableFuture.supplyAsync(() -> {
+			try{
+				return ocr(image, options);
+			}catch(Exception e){
+				return MolvecResult.createFromError(e);
 			}
 		},executor);
 	}
@@ -101,6 +195,16 @@ public final class Molvec {
 			}
 		});
 	}
+	public static CompletableFuture<MolvecResult> ocrAsync(BufferedImage image, MolvecOptions options, Executor executor){
+		return CompletableFuture.supplyAsync(() -> {
+			try{
+				return ocr(image, options);
+			}catch(Exception e){
+				return MolvecResult.createFromError(e);
+			}
+		},executor);
+	}
+
 	public static CompletableFuture<String> ocrAsync(BufferedImage image, Executor executor){
 		return CompletableFuture.supplyAsync(() -> {
 			try{
@@ -111,7 +215,6 @@ public final class Molvec {
 			}
 		},executor);
 	}
-
 
 	
 

--- a/src/main/java/gov/nih/ncats/molvec/MolvecOptions.java
+++ b/src/main/java/gov/nih/ncats/molvec/MolvecOptions.java
@@ -4,13 +4,26 @@ import gov.nih.ncats.molvec.internal.util.CachedSupplier;
 import gov.nih.ncats.molvec.internal.util.ConnectionTable;
 import gov.nih.ncats.molvec.internal.util.GeomUtil;
 
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
-import java.util.Optional;
+import java.text.NumberFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class MolvecOptions {
     private double averageBondLength = 1D;
     private boolean center = true;
     private boolean includeSgroups = true;
+
+    private String name;
+
+    public MolvecOptions setName(String name){
+        this.name = name;
+        return this;
+    }
 
     public MolvecOptions averageBondLength(double averageBondLength){
         if(averageBondLength <=0){
@@ -29,8 +42,8 @@ public class MolvecOptions {
         return this;
     }
 
-    protected MolvecResult computeResult(ConnectionTable ct){
-        String mol= ct.toMol(averageBondLength, center, includeSgroups);
+    public MolvecResult computeResult(ConnectionTable ct){
+        String mol= toMol(ct);
 
         return new Result(mol, CachedSupplier.of(()-> ct.getNodes()
                                                     .stream()
@@ -38,6 +51,247 @@ public class MolvecOptions {
                                                     .collect(GeomUtil.convexHull())
                                                     .getBounds2D()));
     }
+
+    private String toMol(ConnectionTable ct){
+        AffineTransform at = new AffineTransform();
+        double blcur = Math.max(ct.getAverageBondLength(),1);
+
+        double scale = averageBondLength/blcur;
+
+
+
+        at.scale(scale, scale);
+        if(center){
+            if(ct.getNodes().size()>0){
+                Rectangle2D rect=ct.getNodes().stream().map(n->n.getPoint()).collect(GeomUtil.convexHull()).getBounds2D();
+                at.translate(-rect.getCenterX(), -rect.getCenterY());
+            }
+        }
+
+
+
+        String newLine = System.lineSeparator();
+        StringBuilder headerBuilder = new StringBuilder(80);
+        if(name !=null){
+            headerBuilder.append(name);
+        }
+        String header = headerBuilder
+                .append(newLine)
+//		IIPPPPPPPPMMDDYYHHmmddSSssssssssssEEEEEEEEEEEERRRRRR
+//				(FORTRAN: A2<--A8--><---A10-->A2I2<--F10.5-><---F12.5--><-I6-> )
+                .append("  Molvec01")
+                //date/time (M/D/Y,H:m)
+                .append(MOL_DATETIME_FORMATTER.format(LocalDateTime.now()))
+                .append("2D") //always write out 2D coords
+                .append(newLine).append(newLine)
+                .toString();
+
+        String countsLine = new StringBuilder(80)
+                .append(writeMolInt(ct.getNodes().size(), 3))
+                .append(writeMolInt(ct.getEdges().size(), 3))
+                //TODO for now mark eveything as chiral
+                //CDK sets this to 1 only if there's a tetrahedral stereo in molecule
+                .append("  0  0  0  0  0  0  0  0999 V2000")
+                .append(newLine)
+                .toString();
+
+        StringBuilder atomBlockBuilder = makeAtomBlock(ct, at, newLine);
+
+        StringBuilder bondBuilder = makeBondBlock(ct,newLine);
+
+        StringBuilder sgroupBuilder =new StringBuilder(0);
+        if(includeSgroups){
+            sgroupBuilder = makeSGroupBlock(ct, at, newLine, true);
+        }
+
+
+
+        String mol= new StringBuilder(header.length() + countsLine.length() + atomBlockBuilder.length() + bondBuilder.length() +sgroupBuilder.length())
+                .append(header)
+                .append(countsLine)
+                .append(atomBlockBuilder)
+                .append(bondBuilder)
+                .append(sgroupBuilder)
+                .append("M  END")
+                .toString();
+        return mol;
+    }
+
+    private StringBuilder makeBondBlock(ConnectionTable ct, String newLine){
+        StringBuilder bondBuilder = new StringBuilder(ct.getEdges().size() *6);
+        boolean useSingle=true;
+
+        for(ConnectionTable.Edge e : ct.getEdges()){
+            int order = e.getOrder();
+            if(e.isAromatic()){
+                order =4;
+//				order =useSingle? 1: 2;
+//				useSingle = !useSingle;
+            }else if(order <1 || order > 4){
+                order =1;
+            }
+            int bondStereo=0;
+            if(e.getOrder() ==1){
+                if(e.getWedge()){
+                    bondStereo =1; // up
+                }else if(e.getDashed()){
+                    bondStereo=6; //down
+                }
+            }
+
+            bondBuilder.append(writeMolInt(e.getNode1Offset()+1, 3))
+                    .append(writeMolInt(e.getNode2Offset()+1, 3))
+                    .append(writeMolInt(order, 3))
+                    .append(writeMolInt(bondStereo, 3))
+                    .append(newLine);
+
+        }
+        return bondBuilder;
+    }
+    private StringBuilder makeAtomBlock(ConnectionTable ct, AffineTransform at, String newLine){
+        StringBuilder atomBlockBuilder = new StringBuilder(82* ct.getNodes().size());
+        for(ConnectionTable.Node n : ct.getNodes()){
+            Point2D np = at.transform(n.getPoint(), null);
+
+            String sym = n.getSymbol();
+            int massDifference = 0;
+            if(n.getSymbol().equals("D")){
+                sym="H";
+                massDifference=1;
+            }
+
+
+            atomBlockBuilder.append(writeMolDouble(np.getX(), 10))
+                    .append(writeMolDouble(-np.getY(), 10))
+                    .append(writeMolDouble(Double.NaN, 10))	//only write 2d coords
+                    .append(' ')
+                    .append(leftPaddWithSpaces(sym, 3))		//TODO should we check to make sure sym is always < 3 chars?
+                    .append(writeMolInt(massDifference, 2))
+                    .append(writeMolInt(computeMolCharge(n.getCharge()), 3))
+                    .append("  0  0  0  0  0  0  0  0  0  0")		//TODO really compute charge
+                    .append(newLine);
+        }
+        return atomBlockBuilder;
+    }
+
+    private StringBuilder makeSGroupBlock(ConnectionTable ct, AffineTransform at, String newLine, boolean onlyIfTooClose){
+        StringBuilder sgroupBlockBuilder = new StringBuilder();
+        Map<Integer, List<ConnectionTable.Node>> groups = new HashMap<>();
+
+        Map<ConnectionTable.Edge,Integer> bindex = new HashMap<ConnectionTable.Edge,Integer>();
+        for(int i=0;i<ct.getEdges().size();i++){
+            bindex.put(ct.getEdges().get(i), i+1);
+        }
+        Set<Integer> dontDo = new HashSet<>();
+
+        for(ConnectionTable.Node n : ct.getNodes()){
+            if(n.getGroup()!=0){
+                groups.computeIfAbsent(n.getGroup(), k->new ArrayList<>()).add(n);
+                if(onlyIfTooClose){
+                    if(!n.isTooClose())dontDo.add(n.getGroup());
+                }
+            }
+        }
+
+
+        groups.forEach((g,al)->{
+            if(dontDo.contains(g))return;
+            ConnectionTable.Node aNode = al.stream()
+                    .filter(n->n.getAlias()!=null)
+                    .findFirst()
+                    .orElse(null);
+            if(aNode==null)return;
+
+            List<ConnectionTable.Edge> me = al.stream()
+                    .flatMap(n->n.getEdges().stream().filter(e->!e.isInventedBond()))
+                    .distinct()
+                    .collect(Collectors.toList());
+            String l1 = "M  STY  1" +rightPaddWithSpaces(g+"", 4) + " SUP";
+            String l2 = "M  SLB  1" +rightPaddWithSpaces(g+"", 4) + rightPaddWithSpaces(g+"", 4);
+            String la = al.stream().map(n->n.getIndex()+1)
+                    .map(i->rightPaddWithSpaces(i+"", 4))
+                    .collect(Collectors.joining());
+            String bl = me.stream().map(e->bindex.get(e))
+                    .map(i->rightPaddWithSpaces(i+"", 4))
+                    .collect(Collectors.joining());
+
+            String l3 = "M  SAL" + rightPaddWithSpaces(g+"", 4) +rightPaddWithSpaces(al.size()+"", 3) + la;
+            String l4 = "M  SBL" + rightPaddWithSpaces(g+"", 4) +rightPaddWithSpaces(me.size()+"", 3) + bl;
+            String l5 = "M  SMT" + rightPaddWithSpaces(g+"", 4) + " " +aNode.getAlias();
+            //String l6 = "M  SBV" + leftPaddWithSpaces(g+"", 4) + " " +aNode.getAlias();
+            sgroupBlockBuilder.append(l1).append(newLine);
+            sgroupBlockBuilder.append(l2).append(newLine);
+            sgroupBlockBuilder.append(l3).append(newLine);
+            sgroupBlockBuilder.append(l4).append(newLine);
+            sgroupBlockBuilder.append(l5).append(newLine);
+
+        });
+
+        return sgroupBlockBuilder;
+    }
+
+    private static int computeMolCharge(int charge){
+        switch(charge){
+            case -3: return 7;
+            case -2: return 6;
+            case -1: return 5;
+            case 0: return 0;
+            case 1: return 3;
+            case 2: return 2;
+            case 3: return 1;
+            default: return 0;
+        }
+    }
+    private static String writeMolInt(int value, int numDigits){
+        String s = Integer.toString(value);
+        if(s.length()>numDigits){
+            s="0";
+        }
+        return rightPaddWithSpaces(s, numDigits);
+    }
+
+    private static String writeMolDouble(double d, int width) {
+        String value;
+        if (Double.isNaN(d) || Double.isInfinite(d)){
+            value = "0.0000";
+        }else{
+            value = MOL_FLOAT_FORMAT.get().format(d);
+        }
+        return rightPaddWithSpaces(value, width);
+    }
+
+    private static String rightPaddWithSpaces(String value, int numDigits) {
+        int padd = numDigits - value.length();
+        StringBuilder builder = new StringBuilder(numDigits);
+        for(int i=0; i< padd; i++){
+            builder.append(' ');
+        }
+        builder.append(value);
+        return builder.toString();
+    }
+    private static String leftPaddWithSpaces(String value, int numDigits) {
+        int padd = numDigits - value.length();
+        StringBuilder builder = new StringBuilder(numDigits);
+        builder.append(value);
+        for(int i=0; i< padd; i++){
+            builder.append(' ');
+        }
+
+        return builder.toString();
+    }
+
+    private static DateTimeFormatter MOL_DATETIME_FORMATTER = DateTimeFormatter.ofPattern("MMddyyHHmm");
+
+    private static ThreadLocal<NumberFormat> MOL_FLOAT_FORMAT = ThreadLocal.withInitial(()->{
+        NumberFormat nf = NumberFormat.getNumberInstance(Locale.ENGLISH);
+        nf.setMinimumIntegerDigits(1);
+        nf.setMaximumIntegerDigits(4);
+        nf.setMinimumFractionDigits(4);
+        nf.setMaximumFractionDigits(4);
+        nf.setGroupingUsed(false);
+
+        return nf;
+    });
 
     private static class Result implements MolvecResult{
         private final String mol;

--- a/src/main/java/gov/nih/ncats/molvec/MolvecOptions.java
+++ b/src/main/java/gov/nih/ncats/molvec/MolvecOptions.java
@@ -1,0 +1,74 @@
+package gov.nih.ncats.molvec;
+
+import gov.nih.ncats.molvec.internal.util.CachedSupplier;
+import gov.nih.ncats.molvec.internal.util.ConnectionTable;
+import gov.nih.ncats.molvec.internal.util.GeomUtil;
+
+import java.awt.geom.Rectangle2D;
+import java.util.Optional;
+
+public class MolvecOptions {
+    private double averageBondLength = 1D;
+    private boolean center = true;
+    private boolean includeSgroups = true;
+
+    public MolvecOptions averageBondLength(double averageBondLength){
+        if(averageBondLength <=0){
+            throw new IllegalArgumentException("avg bond length must be > 0");
+        }
+        this.averageBondLength = averageBondLength;
+        return this;
+    }
+
+    public MolvecOptions center(boolean center){
+        this.center = center;
+        return this;
+    }
+    public MolvecOptions includeSgroups(boolean includeSgroups){
+        this.includeSgroups = includeSgroups;
+        return this;
+    }
+
+    protected MolvecResult computeResult(ConnectionTable ct){
+        String mol= ct.toMol(averageBondLength, center, includeSgroups);
+
+        return new Result(mol, CachedSupplier.of(()-> ct.getNodes()
+                                                    .stream()
+                                                    .map(n->n.getPoint())
+                                                    .collect(GeomUtil.convexHull())
+                                                    .getBounds2D()));
+    }
+
+    private static class Result implements MolvecResult{
+        private final String mol;
+        private final CachedSupplier<Rectangle2D> boundsSupplier;
+
+
+        public Result(String mol, CachedSupplier<Rectangle2D> boundsSupplier) {
+            this.mol = mol;
+            this.boundsSupplier = boundsSupplier;
+        }
+
+        @Override
+        public Optional<String> getMol() {
+            return Optional.of(mol);
+        }
+
+        @Override
+        public Optional<Rectangle2D> getOriginalBoundingBox() {
+            return Optional.of(boundsSupplier.get());
+        }
+
+        @Override
+        public boolean hasError() {
+            return false;
+        }
+
+        @Override
+        public Optional<Throwable> getError() {
+            return Optional.empty();
+        }
+
+
+    }
+}

--- a/src/main/java/gov/nih/ncats/molvec/MolvecResult.java
+++ b/src/main/java/gov/nih/ncats/molvec/MolvecResult.java
@@ -5,14 +5,33 @@ import java.util.Optional;
 
 /**
  * Object to hold the information of a single molvec image to structure result.
+ *
+ * @since 0.9.8
  */
 public interface MolvecResult {
     /**
      * Returns a molfile of the chemical structure.
      * @return an Optional containing the molfile as String or Empty Optional if there was an error.
      */
-    Optional<String> getMol();
+    Optional<String> getMolfile();
 
+    /**
+     * Returns a SDfile ( structure-data file)  of the chemical structure.
+     * @return an Optional containing the SDfile as String or Empty Optional if there was an error.
+     */
+    default Optional<String> getSDfile(){
+        Optional<String> molfile = getMolfile();
+        if(!molfile.isPresent()){
+            return molfile;
+        }
+        //according to sdfile spec
+        //If the SDfile only contains structures, there can be no blank line between the last "M END"
+        //and the $$$$ delimiter line.
+        String mol = molfile.get();
+        StringBuilder builder = new StringBuilder(mol.length() + 6);
+        return Optional.of(builder.append(mol).append(System.lineSeparator())
+                            .append("$$$$").toString());
+    }
     /**
      * Get the bounding box for the found atoms in the original coordinate
      * system of the processed image.  The returned bounding box may not

--- a/src/main/java/gov/nih/ncats/molvec/MolvecResult.java
+++ b/src/main/java/gov/nih/ncats/molvec/MolvecResult.java
@@ -1,6 +1,7 @@
 package gov.nih.ncats.molvec;
 
 import java.awt.geom.Rectangle2D;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -19,19 +20,13 @@ public interface MolvecResult {
      * Returns a SDfile ( structure-data file)  of the chemical structure.
      * @return an Optional containing the SDfile as String or Empty Optional if there was an error.
      */
-    default Optional<String> getSDfile(){
-        Optional<String> molfile = getMolfile();
-        if(!molfile.isPresent()){
-            return molfile;
-        }
-        //according to sdfile spec
-        //If the SDfile only contains structures, there can be no blank line between the last "M END"
-        //and the $$$$ delimiter line.
-        String mol = molfile.get();
-        StringBuilder builder = new StringBuilder(mol.length() + 6);
-        return Optional.of(builder.append(mol).append(System.lineSeparator())
-                            .append("$$$$").toString());
-    }
+    Optional<String> getSDfile();
+    /**
+     * Returns a SDfile ( structure-data file)  of the chemical structure with the given properties.
+     * @param properties a mapping of properties to include in the formatted SDfile. If null, then no properties are included.
+     * @return an Optional containing the SDfile as String or Empty Optional if there was an error.
+     */
+    Optional<String> getSDfile(Map<String,String> properties);
     /**
      * Get the bounding box for the found atoms in the original coordinate
      * system of the processed image.  The returned bounding box may not

--- a/src/main/java/gov/nih/ncats/molvec/MolvecResult.java
+++ b/src/main/java/gov/nih/ncats/molvec/MolvecResult.java
@@ -3,16 +3,45 @@ package gov.nih.ncats.molvec;
 import java.awt.geom.Rectangle2D;
 import java.util.Optional;
 
+/**
+ * Object to hold the information of a single molvec image to structure result.
+ */
 public interface MolvecResult {
+    /**
+     * Returns a molfile of the chemical structure.
+     * @return an Optional containing the molfile as String or Empty Optional if there was an error.
+     */
     Optional<String> getMol();
 
+    /**
+     * Get the bounding box for the found atoms in the original coordinate
+     * system of the processed image.  The returned bounding box may not
+     * match the atom coordinates in the return mol file
+     * if any transformation to recenter or adjust bond lengths was
+     * used to generate the mol file.
+     * @return an Optional containing a Rectangle2D or an empty optional if there was an error.
+     */
     Optional<Rectangle2D> getOriginalBoundingBox();
 
+    /**
+     * If there was an error during computing the molvec Result.
+     * @return
+     */
     boolean hasError();
 
+    /**
+     * Return the Throwable error if there is one; or empty optional if there is no error.
+     * @return
+     *
+     * @see #hasError()
+     */
     Optional<Throwable> getError();
 
-
+    /**
+     * Factory method to create a MolvecResult that has the given error.
+     * @param t
+     * @return
+     */
     static MolvecResult createFromError(Throwable t){
         return new ErrorResult(t);
     }

--- a/src/main/java/gov/nih/ncats/molvec/MolvecResult.java
+++ b/src/main/java/gov/nih/ncats/molvec/MolvecResult.java
@@ -1,0 +1,19 @@
+package gov.nih.ncats.molvec;
+
+import java.awt.geom.Rectangle2D;
+import java.util.Optional;
+
+public interface MolvecResult {
+    Optional<String> getMol();
+
+    Optional<Rectangle2D> getOriginalBoundingBox();
+
+    boolean hasError();
+
+    Optional<Throwable> getError();
+
+
+    static MolvecResult createFromError(Throwable t){
+        return new ErrorResult(t);
+    }
+}

--- a/src/main/java/gov/nih/ncats/molvec/internal/algo/StructureImageExtractor.java
+++ b/src/main/java/gov/nih/ncats/molvec/internal/algo/StructureImageExtractor.java
@@ -1610,7 +1610,8 @@ public class StructureImageExtractor {
 			double[] lDistOCRToLine=likelyOCR.stream()
 					.map(s->Tuple.of(s,s.centerOfBounds()))
 					.map(Tuple.vmap(p->Tuple.of(p,GeomUtil.findClosestPoint(verts, p))))
-					.map(Tuple.vmap(t->t.k().distance(t.v())))
+					.filter(p->p.k() !=null && p.v().v() !=null)
+                    .map(Tuple.vmap(t->t.k().distance(t.v())))
 					.mapToDouble(t->t.v())
 					.sorted()
 					.toArray();

--- a/src/main/java/gov/nih/ncats/molvec/internal/algo/Tuple.java
+++ b/src/main/java/gov/nih/ncats/molvec/internal/algo/Tuple.java
@@ -163,7 +163,7 @@ public class Tuple<K,V> implements Comparable<Tuple<K,V>>{
 	
 	@Override
 	public String toString(){
-	    return "<" + this.k.toString() + "," + this.v.toString() + ">";
+	    return "<" + k + "," + v + ">";
 	}
 	
 	public static interface ThrowableBiConsumer<K,V> extends BiConsumer<K,V>{

--- a/src/main/java/gov/nih/ncats/molvec/internal/util/ConnectionTable.java
+++ b/src/main/java/gov/nih/ncats/molvec/internal/util/ConnectionTable.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import gov.nih.ncats.molvec.MolvecOptions;
 import gov.nih.ncats.molvec.internal.image.Bitmap;
 import gov.nih.ncats.molvec.internal.algo.Tuple;
 import gov.nih.ncats.molvec.internal.algo.Tuple.KEqualityTuple;
@@ -551,245 +552,11 @@ public class ConnectionTable{
 		.collect(Collectors.toList());
 	}
 	public String toMol(){
-		return toMol(1, true, true);
-	}
-	public String toMol(double averageBondLength, boolean center , boolean includeSgroups){
-		AffineTransform at = new AffineTransform();
-		double blcur = Math.max(this.getAverageBondLength(),1);
-
-		double scale = averageBondLength/blcur;
-
-
-
-		at.scale(scale, scale);
-		if(center){
-			if(this.getNodes().size()>0){
-				Rectangle2D rect=this.getNodes().stream().map(n->n.getPoint()).collect(GeomUtil.convexHull()).getBounds2D();
-				at.translate(-rect.getCenterX(), -rect.getCenterY());
-			}
-		}
-
-
-
-		String newLine = System.lineSeparator();
-		String header = new StringBuilder(80)
-						.append(newLine)
-//		IIPPPPPPPPMMDDYYHHmmddSSssssssssssEEEEEEEEEEEERRRRRR
-//				(FORTRAN: A2<--A8--><---A10-->A2I2<--F10.5-><---F12.5--><-I6-> )
-						.append("  Molvec01")
-				//date/time (M/D/Y,H:m)
-						.append(MOL_DATETIME_FORMATTER.format(LocalDateTime.now()))
-						.append("2D") //always write out 2D coords
-						.append(newLine).append(newLine)
-						.toString();
-
-		String countsLine = new StringBuilder(80)
-						.append(writeMolInt(getNodes().size(), 3))
-						.append(writeMolInt(edges.size(), 3))
-				//TODO for now mark eveything as chiral
-				//CDK sets this to 1 only if there's a tetrahedral stereo in molecule
-						.append("  0  0  0  0  0  0  0  0999 V2000")
-					.append(newLine)
-						.toString();
-
-		StringBuilder atomBlockBuilder = makeAtomBlock(at, newLine);
-
-		StringBuilder bondBuilder = makeBondBlock(newLine);
-		
-		StringBuilder sgroupBuilder =new StringBuilder(0);
-		if(includeSgroups){
-			sgroupBuilder = makeSGroupBlock(at, newLine, true);
-		}
-
-		
-
-		String mol= new StringBuilder(header.length() + countsLine.length() + atomBlockBuilder.length() + bondBuilder.length() +sgroupBuilder.length())
-				.append(header)
-					.append(countsLine)
-				.append(atomBlockBuilder)
-				.append(bondBuilder)
-				.append(sgroupBuilder)
-				.append("M  END")
-						.toString();
-		return mol;
+		return DEFAULT_OPTIONS.computeResult(this).getMol().get();
 	}
 
-	private StringBuilder makeBondBlock(String newLine){
-		StringBuilder bondBuilder = new StringBuilder(edges.size() *6);
-		boolean useSingle=true;
+	private static final MolvecOptions DEFAULT_OPTIONS = new MolvecOptions();
 
-		for(Edge e : edges){
-			int order = e.getOrder();
-			if(e.isAromatic()){
-				order =4;
-//				order =useSingle? 1: 2;
-//				useSingle = !useSingle;
-			}else if(order <1 || order > 4){
-				order =1;
-			}
-			int bondStereo=0;
-			if(e.getOrder() ==1){
-				if(e.getWedge()){
-					bondStereo =1; // up
-				}else if(e.getDashed()){
-					bondStereo=6; //down
-				}
-			}
-
-			bondBuilder.append(writeMolInt(e.n1+1, 3))
-					.append(writeMolInt(e.n2+1, 3))
-					.append(writeMolInt(order, 3))
-					.append(writeMolInt(bondStereo, 3))
-					.append(newLine);
-
-		}
-		return bondBuilder;
-	}
-	private StringBuilder makeAtomBlock(AffineTransform at, String newLine){
-		StringBuilder atomBlockBuilder = new StringBuilder(82* nodes.size());
-		for(Node n : this.nodes){
-			Point2D np = at.transform(n.getPoint(), null);
-
-			String sym = n.symbol;
-			int massDifference = 0;
-			if(n.symbol.equals("D")){
-				sym="H";
-				massDifference=1;
-			}
-
-			
-			atomBlockBuilder.append(writeMolDouble(np.getX(), 10))
-					.append(writeMolDouble(-np.getY(), 10))
-					.append(writeMolDouble(Double.NaN, 10))	//only write 2d coords
-					.append(' ')
-					.append(leftPaddWithSpaces(sym, 3))		//TODO should we check to make sure sym is always < 3 chars?
-					.append(writeMolInt(massDifference, 2))
-					.append(writeMolInt(computeMolCharge(n.charge), 3))
-							.append("  0  0  0  0  0  0  0  0  0  0")		//TODO really compute charge
-			.append(newLine);
-		}
-		return atomBlockBuilder;
-	}
-	
-	private StringBuilder makeSGroupBlock(AffineTransform at, String newLine, boolean onlyIfTooClose){
-		StringBuilder sgroupBlockBuilder = new StringBuilder();
-		Map<Integer, List<Node>> groups = new HashMap<>();
-		
-		Map<Edge,Integer> bindex = new HashMap<Edge,Integer>();
-		for(int i=0;i<this.edges.size();i++){
-			bindex.put(this.edges.get(i), i+1);
-		}
-		Set<Integer> dontDo = new HashSet<>();
-		
-		for(Node n : this.nodes){
-			if(n.getGroup()!=0){
-				groups.computeIfAbsent(n.getGroup(), k->new ArrayList<>()).add(n);
-				if(onlyIfTooClose){
-					if(!n.isTooClose())dontDo.add(n.getGroup());
-				}
-			}
-		}
-		
-		
-		groups.forEach((g,al)->{
-			if(dontDo.contains(g))return;
-			Node aNode = al.stream()
-			.filter(n->n.getAlias()!=null)
-			.findFirst()
-			.orElse(null);
-			if(aNode==null)return;
-			
-			List<Edge> me = al.stream()
-							  .flatMap(n->n.getEdges().stream().filter(e->!e.isInventedBond()))
-							  .distinct()
-							  .collect(Collectors.toList());
-			String l1 = "M  STY  1" +rightPaddWithSpaces(g+"", 4) + " SUP";
-			String l2 = "M  SLB  1" +rightPaddWithSpaces(g+"", 4) + rightPaddWithSpaces(g+"", 4);
-			String la = al.stream().map(n->n.getIndex()+1)
-					   .map(i->rightPaddWithSpaces(i+"", 4))
-					   .collect(Collectors.joining());
-			String bl = me.stream().map(e->bindex.get(e))
-					   .map(i->rightPaddWithSpaces(i+"", 4))
-					   .collect(Collectors.joining());
-			
-			String l3 = "M  SAL" + rightPaddWithSpaces(g+"", 4) +rightPaddWithSpaces(al.size()+"", 3) + la;
-			String l4 = "M  SBL" + rightPaddWithSpaces(g+"", 4) +rightPaddWithSpaces(me.size()+"", 3) + bl;
-			String l5 = "M  SMT" + rightPaddWithSpaces(g+"", 4) + " " +aNode.getAlias();
-			//String l6 = "M  SBV" + leftPaddWithSpaces(g+"", 4) + " " +aNode.getAlias();
-			sgroupBlockBuilder.append(l1).append(newLine);
-			sgroupBlockBuilder.append(l2).append(newLine);
-			sgroupBlockBuilder.append(l3).append(newLine);
-			sgroupBlockBuilder.append(l4).append(newLine);
-			sgroupBlockBuilder.append(l5).append(newLine);
-			
-		});
-		
-		return sgroupBlockBuilder;
-	}
-
-	private static int computeMolCharge(int charge){
-		switch(charge){
-			case -3: return 7;
-			case -2: return 6;
-			case -1: return 5;
-			case 0: return 0;
-			case 1: return 3;
-			case 2: return 2;
-			case 3: return 1;
-			default: return 0;
-		}
-	}
-
-	private static ThreadLocal<NumberFormat> MOL_FLOAT_FORMAT = ThreadLocal.withInitial(()->{
-		NumberFormat nf = NumberFormat.getNumberInstance(Locale.ENGLISH);
-		nf.setMinimumIntegerDigits(1);
-		nf.setMaximumIntegerDigits(4);
-		nf.setMinimumFractionDigits(4);
-		nf.setMaximumFractionDigits(4);
-		nf.setGroupingUsed(false);
-
-		return nf;
-	});
-
-	private static String writeMolInt(int value, int numDigits){
-		String s = Integer.toString(value);
-		if(s.length()>numDigits){
-			s="0";
-		}
-		return rightPaddWithSpaces(s, numDigits);
-	}
-
-	private static String writeMolDouble(double d, int width) {
-		String value;
-		if (Double.isNaN(d) || Double.isInfinite(d)){
-			value = "0.0000";
-		}else{
-			value = MOL_FLOAT_FORMAT.get().format(d);
-		}
-		return rightPaddWithSpaces(value, width);
-	}
-
-	private static String rightPaddWithSpaces(String value, int numDigits) {
-		int padd = numDigits - value.length();
-		StringBuilder builder = new StringBuilder(numDigits);
-		for(int i=0; i< padd; i++){
-			builder.append(' ');
-		}
-		builder.append(value);
-		return builder.toString();
-	}
-	private static String leftPaddWithSpaces(String value, int numDigits) {
-		int padd = numDigits - value.length();
-		StringBuilder builder = new StringBuilder(numDigits);
-		builder.append(value);
-		for(int i=0; i< padd; i++){
-			builder.append(' ');
-		}
-
-		return builder.toString();
-	}
-
-	private static DateTimeFormatter MOL_DATETIME_FORMATTER = DateTimeFormatter.ofPattern("MMddyyHHmm");
 
 
 	public ConnectionTable mergeNodesAverage(int n1, int n2){
@@ -1691,7 +1458,12 @@ public class ConnectionTable{
 			this.n2=n2;
 			this.setOrder(o);
 		}
-		
+		public int getNode1Offset(){
+			return n1;
+		}
+		public int getNode2Offset(){
+			return n2;
+		}
 		public Stream<Node> streamNodes(){
 			return Stream.of(this.getRealNode1(),this.getRealNode2());
 		}

--- a/src/main/java/gov/nih/ncats/molvec/internal/util/ConnectionTable.java
+++ b/src/main/java/gov/nih/ncats/molvec/internal/util/ConnectionTable.java
@@ -1844,7 +1844,8 @@ public class ConnectionTable{
 		double avg=this.getAverageBondLength();
 		List<ShapeWrapper> addShapes=likelyOCR.stream() 
 		         .map(oc->Tuple.of(getClosestNodeToShape(oc),oc))
-		         .filter(t->t.k().v()>avg*mIN_BOND_TO_AVG_BOND_RATIO_FOR_NOVEL)
+		        .filter(t->t.k()!=null && t.k().v() !=null)
+				.filter(t->t.k().v()>avg*mIN_BOND_TO_AVG_BOND_RATIO_FOR_NOVEL)
 				 .filter(t->t.k().v()<avg*mAX_BOND_TO_AVG_BOND_RATIO_FOR_NOVEL)
 				 .map(t->t.v())
 				 .collect(Collectors.toList());

--- a/src/main/java/gov/nih/ncats/molvec/internal/util/ConnectionTable.java
+++ b/src/main/java/gov/nih/ncats/molvec/internal/util/ConnectionTable.java
@@ -5,14 +5,9 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Shape;
 import java.awt.Stroke;
-import java.awt.geom.AffineTransform;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Line2D;
 import java.awt.geom.Point2D;
-import java.awt.geom.Rectangle2D;
-import java.text.NumberFormat;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.BinaryOperator;
 import java.util.function.Consumer;
@@ -552,7 +547,7 @@ public class ConnectionTable{
 		.collect(Collectors.toList());
 	}
 	public String toMol(){
-		return DEFAULT_OPTIONS.computeResult(this).getMol().get();
+		return DEFAULT_OPTIONS.computeResult(this).getMolfile().get();
 	}
 
 	private static final MolvecOptions DEFAULT_OPTIONS = new MolvecOptions();

--- a/src/main/java/gov/nih/ncats/molvec/internal/util/GeomUtil.java
+++ b/src/main/java/gov/nih/ncats/molvec/internal/util/GeomUtil.java
@@ -170,7 +170,9 @@ public class GeomUtil {
                                         + i + "=(" + pi.getX () + "," + pi.getY ()
                                         + ") ccw=" + dir);
                 }
-                if (dir >= 0.) { // push back
+                //this is really a check to make sure dir >=0
+                //but because of floating point math we have to have a delta
+                if (dir >= -0.02) { // push back
                     stack.push (p2);
                     break;
                 }

--- a/src/test/java/gov/nih/ncats/molvec/Java11RegressionTest.java
+++ b/src/test/java/gov/nih/ncats/molvec/Java11RegressionTest.java
@@ -19,7 +19,7 @@ public class Java11RegressionTest {
 
     private void assertMolFileNotBlank(String result) {
         int numLines = result.split("\n").length;
-        assertTrue("blank mol file? only " + numLines + " lines long", numLines > 5);
+        assertTrue("blank mol file? only " + numLines + " lines long\n"+result, numLines > 5);
     }
 
     @Test

--- a/src/test/java/gov/nih/ncats/molvec/internal/algo/RegressionTestIT.java
+++ b/src/test/java/gov/nih/ncats/molvec/internal/algo/RegressionTestIT.java
@@ -55,6 +55,7 @@ import javax.imageio.ImageWriter;
 import javax.imageio.plugins.jpeg.JPEGImageWriteParam;
 import javax.imageio.stream.FileImageOutputStream;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.mortennobel.imagescaling.ResampleOp;
@@ -70,7 +71,7 @@ import gov.nih.ncats.molvec.Molvec;
 import gov.nih.ncats.molvec.internal.algo.ShellCommandRunner.Monitor;
 import gov.nih.ncats.molvec.internal.image.ImageUtil;
 import gov.nih.ncats.molvec.internal.util.GeomUtil;
-
+@Ignore
 public class RegressionTestIT {
 	
 	public static Map<String,AtomicInteger> elementCounts = new ConcurrentHashMap<String, AtomicInteger>();


### PR DESCRIPTION
This should be merged after the other pull request.

While running example usan dataset of the 8800+ image files 7 threw NPEs this changes fix those errors so we get mol files back.  Of those 7 4 now return full mol files and 3 return empty mols since they don't really have structures. I did not check the correctness of those 4 recovered mols.